### PR TITLE
Use latest renovate for config validation

### DIFF
--- a/.github/workflows/check-renovate-config.yaml
+++ b/.github/workflows/check-renovate-config.yaml
@@ -15,4 +15,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Renovate config validator
-        run: npx --package=renovate --yes -- renovate-config-validator --strict
+        run: npx --package=renovate@latest --yes --prefer-online renovate-config-validator --strict


### PR DESCRIPTION
Previously the npx command used wasn't explicitly setting the version of renovate package used to be latest stable version. Instead npx picked 37.440.7 locally and in CI also some older version. Why that version got picked up isn't known, but setting explicitly to latest tag fixes the problem.